### PR TITLE
Change InputStreamReader import to Java

### DIFF
--- a/src/main/java/team/chisel/client/render/ModelLoaderChisel.java
+++ b/src/main/java/team/chisel/client/render/ModelLoaderChisel.java
@@ -4,7 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
 
-import jline.internal.InputStreamReader;
+import java.io.InputStreamReader;
 import net.minecraft.client.renderer.block.model.ModelBlockDefinition;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.IResourceManager;


### PR DESCRIPTION
The Jline version of this library is marked as server-only, and the modpack updater that we use omits this library during launch. NOTE: This fix is applicable to the 1.9 branch as well. This would close #141. 
