### PR TITLE
Allow ModelChiselBlock.getQuads to work with normal block states

### DIFF
--- a/src/main/java/team/chisel/client/render/ModelChiselBlock.java
+++ b/src/main/java/team/chisel/client/render/ModelChiselBlock.java
@@ -11,6 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3f;
 
+import gnu.trove.set.hash.TLongHashSet;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.cache.Cache;
@@ -107,6 +108,9 @@ public class ModelChiselBlock implements IPerspectiveAwareModel {
 
             TLongSet serialized = ctxList.serialized();
             baked = modelcache.get(new State(ext.getClean(), serialized), () -> createModel(state, model, ctxList));
+        } else if (state != null)  {
+            baked = modelcache.get(new State(state, new TLongHashSet()), () -> createModel(state, model, null));
+
         }
         
         BlockRenderLayer layer = MinecraftForgeClient.getRenderLayer();


### PR DESCRIPTION
With the current implementation if ModelChiselBlock.getQuads called with something that isn't a ChiselExtendedState it returns either a null or an empty list because faceQuads/genQuads is only filled in createModel which isn't called in the model registered for the block.

This change allows it to return a default set of quads for a block, allowing the models to be used in other blocks (e.g. as microblock covers).
