### PR TITLE
Cleanup Waila/Hwyla integration

### DIFF
--- a/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
+++ b/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
@@ -38,7 +38,7 @@ public class ChiselDataHandler implements IWailaPlugin, IWailaDataProvider {
     @SideOnly(Side.CLIENT)
     public List<String> getWailaBody(ItemStack stack, List<String> strings, IWailaDataAccessor accessor, IWailaConfigHandler configHandler) {
         ICarvable carvable = (ICarvable) accessor.getBlock();
-        int index = stack.getItemDamage() & carvable.getTotalVariations();
+        int index = stack.getItemDamage() % carvable.getTotalVariations();
         VariationData data = carvable.getVariationData(index);
         String key = stack.getUnlocalizedName() + "." + data.name + ".desc.";
         int line = Configurations.blockDescriptions ? 1 : 2;

--- a/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
+++ b/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
@@ -8,7 +8,6 @@ import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaPlugin;
 import mcp.mobius.waila.api.IWailaRegistrar;
 import mcp.mobius.waila.api.WailaPlugin;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
+++ b/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import team.chisel.api.block.ICarvable;
 import team.chisel.api.block.VariationData;
+import team.chisel.common.config.Configurations;
 
 @WailaPlugin
 public class ChiselDataHandler implements IWailaPlugin, IWailaDataProvider {
@@ -40,8 +41,9 @@ public class ChiselDataHandler implements IWailaPlugin, IWailaDataProvider {
         int index = stack.getItemDamage() & carvable.getTotalVariations();
         VariationData data = carvable.getVariationData(index);
         String key = stack.getUnlocalizedName() + "." + data.name + ".desc.";
-        for (int i = 1; I18n.hasKey(key + i); ++i) {
-            strings.add(I18n.format(key + i));
+        int line = Configurations.blockDescriptions ? 1 : 2;
+        while (I18n.hasKey(key + line)) {
+            strings.add(I18n.format(key + line++));
         }
         return strings;
     }

--- a/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
+++ b/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
@@ -8,6 +8,7 @@ import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaPlugin;
 import mcp.mobius.waila.api.IWailaRegistrar;
 import mcp.mobius.waila.api.WailaPlugin;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
@@ -15,7 +16,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import team.chisel.api.block.ICarvable;
@@ -34,15 +34,11 @@ public class ChiselDataHandler implements IWailaPlugin, IWailaDataProvider {
         return strings;
     }
 
-    @SuppressWarnings("null")
     @Override
     @SideOnly(Side.CLIENT)
     public List<String> getWailaBody(ItemStack stack, List<String> strings, IWailaDataAccessor accessor, IWailaConfigHandler configHandler) {
-        if (accessor.getBlock() instanceof ICarvable) {
-            ItemChiselBlock item = (ItemChiselBlock) ForgeRegistries.ITEMS.getValue(accessor.getBlock().getRegistryName());
-            ICarvable block = (ICarvable) accessor.getBlock();
-            int variation = block.getVariationIndex(accessor.getBlockState());
-            item.addInformation(new ItemStack(item, 1, variation), accessor.getWorld(), strings, ITooltipFlag.TooltipFlags.NORMAL);
+        if (stack.getItem() instanceof ItemChiselBlock) {
+            stack.getItem().addInformation(stack, null, strings, ITooltipFlag.TooltipFlags.NORMAL);
         }
         return strings;
     }

--- a/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
+++ b/src/main/java/team/chisel/common/integration/waila/ChiselDataHandler.java
@@ -8,7 +8,7 @@ import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaPlugin;
 import mcp.mobius.waila.api.IWailaRegistrar;
 import mcp.mobius.waila.api.WailaPlugin;
-import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -18,7 +18,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import team.chisel.api.block.ICarvable;
-import team.chisel.common.block.ItemChiselBlock;
+import team.chisel.api.block.VariationData;
 
 @WailaPlugin
 public class ChiselDataHandler implements IWailaPlugin, IWailaDataProvider {
@@ -36,8 +36,12 @@ public class ChiselDataHandler implements IWailaPlugin, IWailaDataProvider {
     @Override
     @SideOnly(Side.CLIENT)
     public List<String> getWailaBody(ItemStack stack, List<String> strings, IWailaDataAccessor accessor, IWailaConfigHandler configHandler) {
-        if (stack.getItem() instanceof ItemChiselBlock) {
-            stack.getItem().addInformation(stack, null, strings, ITooltipFlag.TooltipFlags.NORMAL);
+        ICarvable carvable = (ICarvable) accessor.getBlock();
+        int index = stack.getItemDamage() & carvable.getTotalVariations();
+        VariationData data = carvable.getVariationData(index);
+        String key = stack.getUnlocalizedName() + "." + data.name + ".desc.";
+        for (int i = 1; I18n.hasKey(key + i); ++i) {
+            strings.add(I18n.format(key + i));
         }
         return strings;
     }


### PR DESCRIPTION
Rewritten to avoid needless registry lookups every tick. Now queries variant name and attempts to localize as many description keys as it can for the stack.