### PR TITLE
Fix crash with disabled autochisel

### DIFF
--- a/src/main/java/team/chisel/client/ClientProxy.java
+++ b/src/main/java/team/chisel/client/ClientProxy.java
@@ -42,9 +42,11 @@ public class ClientProxy extends CommonProxy {
             ModelLoader.setCustomModelResourceLocation(ChiselItems.offsettool, 0, new ModelResourceLocation(ChiselItems.offsettool.getRegistryName(), "inventory"));
         }
         
-        ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(ChiselBlocks.auto_chisel), 0, new ModelResourceLocation(ChiselBlocks.auto_chisel.getRegistryName(), "normal"));
-        ClientRegistry.bindTileEntitySpecialRenderer(TileAutoChisel.class, new RenderAutoChisel());
-
+        if (Features.AUTOCHISEL.enabled()) {
+            ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(ChiselBlocks.auto_chisel), 0, new ModelResourceLocation(ChiselBlocks.auto_chisel.getRegistryName(), "normal"));
+            ClientRegistry.bindTileEntitySpecialRenderer(TileAutoChisel.class, new RenderAutoChisel());
+        }
+        
         // ModelBakery.addVariantName(Chisel.itemChisel, MOD_ID+":itemChisel");
         // MinecraftForge.EVENT_BUS.register(new CTMModelRegistry.BakedEventListener());
         // MinecraftForge.EVENT_BUS.register(new NonCTMModelRegistry.BakedEventListener());


### PR DESCRIPTION
If autochisel block is disabled in config file we are will get client crash (NPE). Referenced issue https://github.com/Chisel-Team/Chisel/issues/677