### PR TITLE
[1.15.2] iChisel - Only show "Chisel All" button when there are multiple selections and a target block selected

### DIFF
--- a/src/main/java/team/chisel/client/gui/GuiHitechChisel.java
+++ b/src/main/java/team/chisel/client/gui/GuiHitechChisel.java
@@ -317,7 +317,7 @@ public class GuiHitechChisel extends GuiChisel<ContainerChiselHitech> {
             initZoom = zoom;
         }
 
-        if (hasShiftDown() && !container.getSelectionDuplicates().isEmpty()) {
+        if (container.getTarget() != null && hasShiftDown() && !container.getSelectionDuplicates().isEmpty()) {
             buttonChisel.setMessage(ChiselLangKeys.BUTTON_CHISEL_ALL.getComponent().applyTextStyle(TextFormatting.YELLOW).getFormattedText());
         } else {
             buttonChisel.setMessage(ChiselLangKeys.BUTTON_CHISEL.getLocalizedText());

--- a/src/main/java/team/chisel/client/gui/GuiHitechChisel.java
+++ b/src/main/java/team/chisel/client/gui/GuiHitechChisel.java
@@ -317,7 +317,7 @@ public class GuiHitechChisel extends GuiChisel<ContainerChiselHitech> {
             initZoom = zoom;
         }
 
-        if (hasShiftDown()) {
+        if (hasShiftDown() && !container.getSelectionDuplicates().isEmpty()) {
             buttonChisel.setMessage(ChiselLangKeys.BUTTON_CHISEL_ALL.getComponent().applyTextStyle(TextFormatting.YELLOW).getFormattedText());
         } else {
             buttonChisel.setMessage(ChiselLangKeys.BUTTON_CHISEL.getLocalizedText());


### PR DESCRIPTION
In the iChisel gui, if there is only one selection/no target, I think it's confusing that the button label changes but the resulting button action remains the same. This pull request makes it so that the "Chisel All" label will only appear if there is a target result and there are duplicate selections.

Not sure how you'd feel about this, might just be my personal preference.